### PR TITLE
Allow defining product types in attribute creation

### DIFF
--- a/saleor/graphql/attribute/tests/mutations/test_attribute_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_create.py
@@ -33,6 +33,16 @@ CREATE_ATTRIBUTE_MUTATION = """
                 unit
                 inputType
                 entityType
+                referenceTypes {
+                    ... on ProductType {
+                        id
+                        slug
+                    }
+                    ... on PageType {
+                        id
+                        slug
+                    }
+                }
                 filterableInStorefront
                 filterableInDashboard
                 availableInGrid
@@ -1444,3 +1454,413 @@ def test_create_attribute_similar_names(
     assert len(values_edges) == 2
     slugs = [node["node"]["slug"] for node in values_edges]
     assert set(slugs) == {"15", "15-2"}
+
+
+@pytest.mark.parametrize(
+    "input_type",
+    [
+        AttributeInputTypeEnum.SINGLE_REFERENCE.name,
+        AttributeInputTypeEnum.REFERENCE.name,
+    ],
+)
+def test_create_product_reference_attribute_with_reference_types(
+    input_type,
+    staff_api_client,
+    permission_manage_product_types_and_attributes,
+    permission_manage_products,
+    product_type,
+):
+    # given
+    query = CREATE_ATTRIBUTE_MUTATION
+
+    attribute_name = "Reference attribute"
+    product_reference_type_id = graphene.Node.to_global_id(
+        "ProductType", product_type.id
+    )
+    type = AttributeTypeEnum.PRODUCT_TYPE.name
+    entity_type = AttributeEntityTypeEnum.PRODUCT.name
+    variables = {
+        "input": {
+            "name": attribute_name,
+            "type": type,
+            "inputType": input_type,
+            "entityType": entity_type,
+            "referenceTypes": [product_reference_type_id],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["attributeCreate"]["errors"]
+    data = content["data"]["attributeCreate"]
+
+    # Check if the attribute was correctly created
+    assert data["attribute"]["name"] == attribute_name
+    assert data["attribute"]["slug"] == slugify(attribute_name)
+    assert data["attribute"]["productTypes"]["edges"] == []
+    assert data["attribute"]["type"] == type
+    assert data["attribute"]["inputType"] == input_type
+    assert data["attribute"]["entityType"] == entity_type
+    assert len(data["attribute"]["referenceTypes"]) == 1
+    assert data["attribute"]["referenceTypes"][0]["id"] == product_reference_type_id
+    assert data["attribute"]["referenceTypes"][0]["slug"] == product_type.slug
+
+
+@pytest.mark.parametrize(
+    "input_type",
+    [
+        AttributeInputTypeEnum.SINGLE_REFERENCE.name,
+        AttributeInputTypeEnum.REFERENCE.name,
+    ],
+)
+def test_create_variant_reference_attribute_with_reference_types(
+    input_type,
+    staff_api_client,
+    permission_manage_page_types_and_attributes,
+    permission_manage_products,
+    product_type,
+    product_type_with_product_attributes,
+):
+    # given
+    query = CREATE_ATTRIBUTE_MUTATION
+
+    attribute_name = "Reference attribute"
+    type = AttributeTypeEnum.PAGE_TYPE.name
+    entity_type = AttributeEntityTypeEnum.PRODUCT_VARIANT.name
+    product_type_ids = [
+        graphene.Node.to_global_id("ProductType", ref_type.id)
+        for ref_type in [product_type_with_product_attributes, product_type]
+    ]
+    variables = {
+        "input": {
+            "name": attribute_name,
+            "type": type,
+            "inputType": input_type,
+            "entityType": entity_type,
+            "referenceTypes": product_type_ids,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[
+            permission_manage_page_types_and_attributes,
+            permission_manage_products,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["attributeCreate"]["errors"]
+    data = content["data"]["attributeCreate"]
+
+    # Check if the attribute was correctly created
+    assert data["attribute"]["name"] == attribute_name
+    assert data["attribute"]["slug"] == slugify(attribute_name)
+    assert data["attribute"]["productTypes"]["edges"] == []
+    assert data["attribute"]["type"] == type
+    assert data["attribute"]["inputType"] == input_type
+    assert data["attribute"]["entityType"] == entity_type
+    assert len(data["attribute"]["referenceTypes"]) == len(product_type_ids)
+    assert {ref_type["id"] for ref_type in data["attribute"]["referenceTypes"]} == set(
+        product_type_ids
+    )
+
+
+@pytest.mark.parametrize(
+    "input_type",
+    [
+        AttributeInputTypeEnum.SINGLE_REFERENCE.name,
+        AttributeInputTypeEnum.REFERENCE.name,
+    ],
+)
+def test_create_page_reference_attribute_with_reference_types(
+    input_type,
+    staff_api_client,
+    permission_manage_product_types_and_attributes,
+    permission_manage_products,
+    page_type_list,
+):
+    # given
+    query = CREATE_ATTRIBUTE_MUTATION
+
+    attribute_name = "Reference attribute"
+    type = AttributeTypeEnum.PRODUCT_TYPE.name
+    entity_type = AttributeEntityTypeEnum.PAGE.name
+    page_type_ids = [
+        graphene.Node.to_global_id("PageType", ref_type.id)
+        for ref_type in page_type_list
+    ]
+    variables = {
+        "input": {
+            "name": attribute_name,
+            "type": type,
+            "inputType": input_type,
+            "entityType": entity_type,
+            "referenceTypes": page_type_ids,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["attributeCreate"]["errors"]
+    data = content["data"]["attributeCreate"]
+
+    # Check if the attribute was correctly created
+    assert data["attribute"]["name"] == attribute_name
+    assert data["attribute"]["slug"] == slugify(attribute_name)
+    assert data["attribute"]["productTypes"]["edges"] == []
+    assert data["attribute"]["type"] == type
+    assert data["attribute"]["inputType"] == input_type
+    assert data["attribute"]["entityType"] == entity_type
+    assert len(data["attribute"]["referenceTypes"]) == len(page_type_ids)
+    assert {ref_type["id"] for ref_type in data["attribute"]["referenceTypes"]} == set(
+        page_type_ids
+    )
+
+
+@pytest.mark.parametrize(
+    "entity_type",
+    [
+        AttributeEntityTypeEnum.COLLECTION.name,
+        AttributeEntityTypeEnum.CATEGORY.name,
+    ],
+)
+def test_create_reference_attribute_with_reference_types_not_valid_entity_type(
+    entity_type,
+    staff_api_client,
+    permission_manage_product_types_and_attributes,
+    permission_manage_products,
+    product_type,
+):
+    # given
+    query = CREATE_ATTRIBUTE_MUTATION
+
+    attribute_name = "Reference attribute"
+    type = AttributeTypeEnum.PRODUCT_TYPE.name
+    input_type = AttributeInputTypeEnum.REFERENCE.name
+    product_reference_type_id = graphene.Node.to_global_id(
+        "ProductType", product_type.id
+    )
+    variables = {
+        "input": {
+            "name": attribute_name,
+            "type": type,
+            "inputType": input_type,
+            "entityType": entity_type,
+            "referenceTypes": [product_reference_type_id],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["attributeCreate"]["attribute"]
+    errors = content["data"]["attributeCreate"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "referenceTypes"
+    assert errors[0]["code"] == AttributeErrorCode.INVALID.name
+
+
+def test_create_attribute_with_reference_types_invalid_input_type(
+    staff_api_client,
+    permission_manage_product_types_and_attributes,
+    permission_manage_products,
+    product_type,
+):
+    # given
+    query = CREATE_ATTRIBUTE_MUTATION
+
+    attribute_name = "Reference attribute"
+    input_type = AttributeInputTypeEnum.DROPDOWN.name
+    product_reference_type_id = graphene.Node.to_global_id(
+        "ProductType", product_type.id
+    )
+    variables = {
+        "input": {
+            "name": attribute_name,
+            "type": AttributeTypeEnum.PRODUCT_TYPE.name,
+            "inputType": input_type,
+            "referenceTypes": [product_reference_type_id],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["attributeCreate"]["attribute"]
+    errors = content["data"]["attributeCreate"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "referenceTypes"
+    assert errors[0]["code"] == AttributeErrorCode.INVALID.name
+
+
+@mock.patch("saleor.graphql.attribute.mutations.mixins.REFERENCE_TYPES_LIMIT", 1)
+def test_create_attribute_with_reference_types_limit_exceeded(
+    staff_api_client,
+    permission_manage_product_types_and_attributes,
+    permission_manage_products,
+    product_type,
+    product_type_with_product_attributes,
+):
+    # given
+    query = CREATE_ATTRIBUTE_MUTATION
+
+    attribute_name = "Single variant reference attribute"
+    input_type = AttributeInputTypeEnum.REFERENCE.name
+    product_type_ids = [
+        graphene.Node.to_global_id("ProductType", ref_type.id)
+        for ref_type in [product_type_with_product_attributes, product_type]
+    ]
+    variables = {
+        "input": {
+            "name": attribute_name,
+            "type": AttributeTypeEnum.PRODUCT_TYPE.name,
+            "entityType": AttributeEntityTypeEnum.PRODUCT_VARIANT.name,
+            "inputType": input_type,
+            "referenceTypes": product_type_ids,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["attributeCreate"]["attribute"]
+    errors = content["data"]["attributeCreate"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "referenceTypes"
+    assert errors[0]["code"] == AttributeErrorCode.INVALID.name
+
+
+def test_create_attribute_with_reference_types_page_types_provided_for_variant_ref(
+    staff_api_client,
+    permission_manage_product_types_and_attributes,
+    permission_manage_products,
+    page_type_list,
+):
+    # given
+    query = CREATE_ATTRIBUTE_MUTATION
+
+    attribute_name = "Single variant reference attribute"
+    input_type = AttributeInputTypeEnum.REFERENCE.name
+    page_type_ids = [
+        graphene.Node.to_global_id("PageType", ref_type.id)
+        for ref_type in page_type_list
+    ]
+    variables = {
+        "input": {
+            "name": attribute_name,
+            "type": AttributeTypeEnum.PRODUCT_TYPE.name,
+            "entityType": AttributeEntityTypeEnum.PRODUCT_VARIANT.name,
+            "inputType": input_type,
+            "referenceTypes": page_type_ids,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["attributeCreate"]["attribute"]
+    errors = content["data"]["attributeCreate"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "referenceTypes"
+    assert errors[0]["code"] == AttributeErrorCode.INVALID.name
+
+
+def test_create_attribute_with_reference_types_product_types_provided_for_page_ref(
+    staff_api_client,
+    permission_manage_product_types_and_attributes,
+    permission_manage_products,
+    product_type,
+):
+    # given
+    query = CREATE_ATTRIBUTE_MUTATION
+
+    attribute_name = "Single variant reference attribute"
+    input_type = AttributeInputTypeEnum.REFERENCE.name
+    product_type_id = graphene.Node.to_global_id("ProductType", product_type.id)
+    variables = {
+        "input": {
+            "name": attribute_name,
+            "type": AttributeTypeEnum.PRODUCT_TYPE.name,
+            "entityType": AttributeEntityTypeEnum.PAGE.name,
+            "inputType": input_type,
+            "referenceTypes": [product_type_id],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["attributeCreate"]["attribute"]
+    errors = content["data"]["attributeCreate"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "referenceTypes"
+    assert errors[0]["code"] == AttributeErrorCode.INVALID.name

--- a/saleor/graphql/core/tests/test_query_cost_validation.py
+++ b/saleor/graphql/core/tests/test_query_cost_validation.py
@@ -1,6 +1,5 @@
 import graphene
 import pytest
-from django.conf import settings
 from django.test import override_settings
 
 
@@ -236,82 +235,3 @@ def test_query_with_fragments_have_same_multiplied_complexity_cost(
     assert json_response["data"] == expected_data
     query_cost = json_response["extensions"]["cost"]["requestedQueryCost"]
     assert query_cost == 120
-
-
-ATTRIBUTE_QUERY_WITH_LIMIT = """
-query($limit: Int) {
-  attributes(first:100) {
-    edges {
-      node {
-        id
-        name
-        referenceTypes(limit: $limit) {
-          ... on ProductType{
-            id
-            slug
-          }
-        }
-      }
-    }
-  }
-}
-"""
-
-
-def test_query_with_empty_not_required_limit_argument(
-    api_client,
-    product_type_product_single_reference_attribute,
-    product_type,
-    product_type_with_product_attributes,
-    product_type_variant_single_reference_attribute,
-):
-    # given
-    product_type_product_single_reference_attribute.reference_product_types.add(
-        product_type, product_type_with_product_attributes
-    )
-    product_type_variant_single_reference_attribute.reference_product_types.add(
-        product_type
-    )
-
-    variables = {"limit": None}
-
-    # when
-    response = api_client.post_graphql(ATTRIBUTE_QUERY_WITH_LIMIT, variables)
-    json_response = response.json()
-
-    # then
-    assert "errors" not in json_response
-    assert json_response["data"]["attributes"]["edges"]
-    query_cost = json_response["extensions"]["cost"]["requestedQueryCost"]
-    assert (
-        query_cost == 100 * 1 + 100 * settings.NESTED_QUERY_LIMIT
-    )  # 100 attributes + 100 product types (limit value) per attribute
-
-
-def test_query_with_not_required_limit_argument_not_provided(
-    api_client,
-    product_type_product_single_reference_attribute,
-    product_type,
-    product_type_with_product_attributes,
-    product_type_variant_single_reference_attribute,
-):
-    # given
-    product_type_product_single_reference_attribute.reference_product_types.add(
-        product_type, product_type_with_product_attributes
-    )
-    product_type_variant_single_reference_attribute.reference_product_types.add(
-        product_type
-    )
-    variables = {}
-
-    # when
-    response = api_client.post_graphql(ATTRIBUTE_QUERY_WITH_LIMIT, variables)
-    json_response = response.json()
-
-    # then
-    assert "errors" not in json_response
-    assert json_response["data"]["attributes"]["edges"]
-    query_cost = json_response["extensions"]["cost"]["requestedQueryCost"]
-    assert (
-        query_cost == 100 * 1 + 100 * settings.NESTED_QUERY_LIMIT
-    )  # 100 attributes + 100 product types (limit value) per attribute

--- a/saleor/graphql/core/validators/__init__.py
+++ b/saleor/graphql/core/validators/__init__.py
@@ -215,3 +215,15 @@ def validate_if_int_or_uuid(id):
             UUID(id)
         except (AttributeError, ValueError) as e:
             raise ValidationError("Must receive an int or UUID.") from e
+
+
+def validate_limit_of_list_input(
+    input_list: list,
+    limit: int,
+    field_name: str,
+):
+    """Validate if the length of the input list does not exceed the limit."""
+    if len(input_list) > limit:
+        raise ValidationError(
+            f"The maximum number of items in {field_name} is {limit}."
+        )

--- a/saleor/graphql/core/validators/query_cost.py
+++ b/saleor/graphql/core/validators/query_cost.py
@@ -3,7 +3,6 @@ from operator import add, mul
 from typing import Any, cast
 
 from graphql import (
-    GraphQLArgument,
     GraphQLError,
     GraphQLInterfaceType,
     GraphQLObjectType,
@@ -85,8 +84,6 @@ class CostValidator(ValidationRule):
                     report_error(self.context, e)
                     field_args = {}
 
-                field_args = self.update_empty_args_with_default(field_args, field.args)
-
                 if not self.cost_map:
                     return 0
 
@@ -125,17 +122,6 @@ class CostValidator(ValidationRule):
                 )
             total += node_cost
         return total
-
-    def update_empty_args_with_default(
-        self, field_args: dict[str, Any], args_defs: dict[str, GraphQLArgument]
-    ) -> dict[str, Any]:
-        """Update empty args with default values from argument definition."""
-        for arg_name, value in field_args.items():
-            if value is None and arg_name in args_defs:
-                arg_def = args_defs[arg_name]
-                if arg_def.default_value is not None:
-                    field_args[arg_name] = arg_def.default_value
-        return field_args
 
     def enter_operation_definition(self, node, key, parent, path, ancestors):  # pylint: disable=unused-argument
         if self.cost_map:

--- a/saleor/graphql/query_cost_map.py
+++ b/saleor/graphql/query_cost_map.py
@@ -145,7 +145,6 @@ COST_MAP = {
         "choices": {"complexity": 1, "multipliers": ["first", "last"]},
         "productTypes": {"complexity": 1, "multipliers": ["first", "last"]},
         "productVariantTypes": {"complexity": 1, "multipliers": ["first", "last"]},
-        "referenceTypes": {"complexity": 1, "multipliers": ["limit"]},
     },
     "Category": {
         "ancestors": {"complexity": 1, "multipliers": ["first", "last"]},

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -28793,6 +28793,15 @@ input AttributeCreateInput @doc(category: "Attributes") {
 
   """External ID of this attribute."""
   externalReference: String
+
+  """
+  Specifies reference types to narrow down the choices of reference objects. Applicable only for `REFERENCE` and `SINGLE_REFERENCE` attributes with `PRODUCT`, `PRODUCT_VARIANT` and `PAGE` entity types. Accepts `ProductType` IDs for `PRODUCT` and `PRODUCT_VARIANT` entity types, and `PageType` IDs for `PAGE` entity type. If omitted, all objects of the selected entity type are available as attribute values.
+  
+  A maximum of 100 reference types can be specified.
+  
+  Added in Saleor 3.22.
+  """
+  referenceTypes: [ID!]
 }
 
 input AttributeValueCreateInput @doc(category: "Attributes") {
@@ -28900,6 +28909,15 @@ input AttributeUpdateInput @doc(category: "Attributes") {
 
   """External ID of this product."""
   externalReference: String
+
+  """
+  Specifies reference types to narrow down the choices of reference objects. Applicable only for `REFERENCE` and `SINGLE_REFERENCE` attributes with `PRODUCT`, `PRODUCT_VARIANT` and `PAGE` entity types. Accepts `ProductType` IDs for `PRODUCT` and `PRODUCT_VARIANT` entity types, and `PageType` IDs for `PAGE` entity type. If omitted, all objects of the selected entity type are available as attribute values.
+  
+  A maximum of 100 reference types can be specified.
+  
+  Added in Saleor 3.22.
+  """
+  referenceTypes: [ID!]
 }
 
 input AttributeValueUpdateInput @doc(category: "Attributes") {


### PR DESCRIPTION
Recreated from original PR: https://github.com/saleor/saleor/pull/18047

Allow defining product types in `AttributeCreate` and `AttributeUpdate`

💡 
Update for bulk mutations will be delivered in separate PR 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://...